### PR TITLE
Scanning phase doesn't skip steps anymore

### DIFF
--- a/Tosr/BiddingState.cs
+++ b/Tosr/BiddingState.cs
@@ -11,6 +11,7 @@
         public int bidId { get; set; }
         public Bid currentBid { get; set; }
         public int relayBidIdLastFase { get; set; }
+        public int relaysInScanningFase { get; set; }
 
         public void Init()
         {
@@ -19,6 +20,7 @@
             bidId = int.MaxValue;
             currentBid = Bid.PassBid;
             relayBidIdLastFase = 0;
+            relaysInScanningFase = 0;
         }
     }
 }

--- a/Tosr/Form1.cs
+++ b/Tosr/Form1.cs
@@ -97,6 +97,10 @@ namespace Tosr
         {
             biddingState.currentBid = Common.NextBid(biddingState.currentBid);
             biddingState.lastBidId = Common.GetBidId(biddingState.currentBid);
+            if (biddingState.fase == Fase.Scanning && biddingState.relayBidIdLastFase != biddingState.lastBidId)
+            {
+                biddingState.relaysInScanningFase += 1;
+            }
         }
 
         private static void SouthBid(BiddingState biddingState, string handsString, bool requestDescription)
@@ -104,9 +108,9 @@ namespace Tosr
             var description = new StringBuilder(128);
 
             var bidFromRule = requestDescription ?
-                    Pinvoke.GetBidFromRuleEx(biddingState.fase, handsString, biddingState.lastBidId - biddingState.relayBidIdLastFase, out Fase nextfase, description) :
-                    Pinvoke.GetBidFromRule(biddingState.fase, handsString, biddingState.lastBidId - biddingState.relayBidIdLastFase, out nextfase);
-            biddingState.bidId = bidFromRule + biddingState.relayBidIdLastFase;
+                    Pinvoke.GetBidFromRuleEx(biddingState.fase, handsString, biddingState.lastBidId - biddingState.relayBidIdLastFase - biddingState.relaysInScanningFase, out Fase nextfase, description) :
+                    Pinvoke.GetBidFromRule(biddingState.fase, handsString, biddingState.lastBidId - biddingState.relayBidIdLastFase - biddingState.relaysInScanningFase, out nextfase);
+            biddingState.bidId = bidFromRule + biddingState.relayBidIdLastFase + biddingState.relaysInScanningFase;
             if (bidFromRule == 0)
             {
                 biddingState.currentBid = Bid.PassBid;


### PR DESCRIPTION
In de scanning fase was er een inconsistentie tussen lastBidId en relBidId. Om dit op te lossen heb ik een extra variabele geïntroduceerd in de biddingState die het aantal relays in de scanning fase telt.